### PR TITLE
4 issues @ Bluetooth OBD

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDDeviceListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDDeviceListAdapter.java
@@ -132,7 +132,7 @@ public class OBDDeviceListAdapter extends ArrayAdapter<BluetoothDevice> {
         // If there exists an already selected bluetooth device and the device of this entry
         // matches the selected device, then set it to checked.
         if (mSelectedBluetoothDevice != null) {
-            if (mSelectedBluetoothDevice.getName().equals(device.getName())) {
+            if (mSelectedBluetoothDevice.getAddress().equals(device.getAddress())) {
                 mSelectedRadioButton = holder.mRadioButton;
                 mSelectedRadioButton.setChecked(true);
                 mSelectedBluetoothDevice = device;

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -265,8 +265,10 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
                                 // If discovering of a device takes more than 15 sec it is still discovered
                                 // and added to mNewDevicesArrayAdapter but displayed as discovery is finished
                                 // if the needed device is not found , redecover button is used.
-                                mProgressBar.setVisibility(View.GONE);
-                                showSnackbar("Discovery Finished!");
+                                if (mBluetoothHandler.isBluetoothEnabled()) {
+                                    mProgressBar.setVisibility(View.GONE);
+                                    showSnackbar("Discovery Finished!");
+                                }
                             }
                         }.start();
 

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -21,6 +21,7 @@ package org.envirocar.app.views.obdselection;
 import android.app.AlertDialog;
 import android.bluetooth.BluetoothDevice;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -116,8 +117,10 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
         // Setup the paired devices.
         updatePairedDevicesList();
 
+        rediscover();
+
         // Start the discovery of bluetooth devices.
-        updateContentView();
+        //updateContentView();
 
         //        // TODO: very ugly... Instead a dynamic LinearLayout should be used.
         //        setDynamicListHeight(mNewDevicesListView);
@@ -145,8 +148,12 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
 
     @OnClick(R.id.activity_obd_selection_layout_rescan_bluetooth)
     protected void rediscover() {
-        mBluetoothHandler.stopBluetoothDeviceDiscovery();
-        updateContentView();
+        if(mBluetoothHandler.isDiscovering()) {
+            mBluetoothHandler.stopBluetoothDeviceDiscovery();
+            updateContentView();
+        }
+        else
+            updateContentView();
     }
     /**
      * Updates the content view.
@@ -184,6 +191,9 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
         // the current adapter.
         mNewDevicesArrayAdapter.clear();
 
+        if (mBluetoothHandler.isDiscovering())
+        mProgressBar.setVisibility(View.VISIBLE);
+
         mBTDiscoverySubscription = mBluetoothHandler.startBluetoothDiscoveryOnlyUnpaired()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -211,8 +221,6 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
                         LOGGER.info("Bluetooth discovery finished.");
 
                         // Dismiss the progressbar.
-                        mProgressBar.setVisibility(View.GONE);
-
                         // If no devices found, set the corresponding textview to visibile.
                         if (mNewDevicesArrayAdapter.isEmpty()) {
                             mNewDevicesInfoTextView.setText(R.string
@@ -226,8 +234,6 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
                             mNewDevicesInfoTextView.setText(String.format(string,
                                     Integer.toString(mNewDevicesArrayAdapter.getCount())));
                         }
-
-                        showSnackbar("Discovery Finished!");
                     }
 
                     @Override
@@ -246,10 +252,35 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
                         if (!mPairedDevicesAdapter.contains(device) &&
                                 !mNewDevicesArrayAdapter.contains(device)) {
                             mNewDevicesArrayAdapter.add(device);
+
                         }
+
+                        // Set timer for 15sec ,
+                        new CountDownTimer(15000, 1000) {
+                            @Override
+                            public void onTick(long millisUntilFinished) {
+                            }
+                            @Override
+                            public void onFinish() {
+                                // If discovering of a device takes more than 15 sec it is still discovered
+                                // and added to mNewDevicesArrayAdapter but displayed as discovery is finished
+                                // if the needed device is not found , redecover button is used.
+                                mProgressBar.setVisibility(View.GONE);
+                                showSnackbar("Discovery Finished!");
+                            }
+                        }.start();
+
+
                     }
                 });
+
+
+
+
+
+
     }
+
 
     private void setupListViews() {
         BluetoothDevice selectedBTDevice = mBluetoothHandler.getSelectedBluetoothDevice();


### PR DESCRIPTION
### **Issues:**

1.  Message when user enters the app "Discovery Finished " but the new devices are added after the toast message
2. During this discovery of new devices, User doesnot know wether the discovering is taking place or not.
3.  sometimes , the discovery of new devices is take significant longer time. Rediscover is a better option than to waiting. 
4. Toast message when the Bluetooth is disabled when discovery 


https://user-images.githubusercontent.com/70392921/119310807-e8f96080-bc8d-11eb-8ff5-c467da8e0bdd.mp4


Solution --
Most cases the needed device we are looking appears below 10 sec or doesnot appear at all. 
Progressbar is turned off after 15 sec of discovery and toast message is displayed as discovery finished. User rediscovers after 15 sec to find the available device than to wait.


https://user-images.githubusercontent.com/70392921/119311137-50171500-bc8e-11eb-91e3-adab014ce1fd.mp4

4th point:-

https://user-images.githubusercontent.com/70392921/119316491-a2f3cb00-bc94-11eb-8a27-e6d8d2a38e22.mp4  

https://user-images.githubusercontent.com/70392921/119316454-9a02f980-bc94-11eb-835e-9d3ef0fedeee.mp4

